### PR TITLE
fix broken xml version in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,4 +1,4 @@
-<?xml version="1.6.3"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="io.branch.sdk" version="1.6.3">
 	<name>BranchSDK</name>
 	<description>Branch SDK Plugin</description>


### PR DESCRIPTION
fix broken xml version in plugin.xml, which is causing problems in phonegap build and other build tools.