### PR TITLE
Account for the fact that the app delegate may have an implementation…

### DIFF
--- a/cordova-src/ios/AppDelegate+BNCDevice.m
+++ b/cordova-src/ios/AppDelegate+BNCDevice.m
@@ -1,10 +1,36 @@
 #import "AppDelegate+BNCDevice.h"
 #import "BNCDevice.h"
+#import <objc/runtime.h>
 
 @implementation AppDelegate (BNCDevice)
 
-- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler {
+static BOOL swizzled = NO;
+
++ (void)load {
+    // only need to worry about this in iOS 8 and later
+    NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+    if ([processInfo respondsToSelector:@selector(operatingSystemVersion)]) {
+        //operatingSystemVersion was introduced in iOS 8
+        Method swizzlee = class_getInstanceMethod(self, @selector(application:continueUserActivity:restorationHandler:));
+        Method swizzler = class_getInstanceMethod(self, @selector(swizzleApplication:continueUserActivity:restorationHandler:));
+        
+        if (swizzlee) {
+            method_exchangeImplementations(swizzlee, swizzler);
+            swizzled = YES;
+        } else {
+            // app delegate has not implemented optional protocol method. add it in with our implementation
+            const char *typeEncoding = method_getTypeEncoding(swizzler);
+            class_addMethod(self, @selector(application:continueUserActivity:restorationHandler:), method_getImplementation(swizzler), typeEncoding);
+        }
+    }
+}
+
+- (BOOL)swizzleApplication:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler {
     if (![userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
+        if (swizzled) {
+            return [self swizzleApplication:application continueUserActivity:userActivity restorationHandler:restorationHandler];
+        }
+        
         return NO;
     }
     


### PR DESCRIPTION
… of application:continueUserActivity:

If the app supports Spotlight Search or Handoff then its delegate likely already has that method implemented. The current implementation in the AppDelegate category replaces any implementation already present (although the objective-c docs say the runtime behavior is undefined).

The approach I take is to swizzle any existing implementation with one contained in the category. If no existing implementation exists, then the category simply adds the implementation at runtime.

The swizzle technique is well documented. Refer to:  
[MethodReplacement](https://developer.apple.com/legacy/library/samplecode/MethodReplacement/Introduction/Intro.html#//apple_ref/doc/uid/DTS10004023-Intro-DontLinkElementID_2)

