### PR TITLE
Updated plugin to set API keys using cordova CLI variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,44 @@ _____
 The plugin can be added in a number of ways. You can grab that latest version on the master Branch by using this call.
 
 ```sh
-cordova plugin add https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK.git
+cordova plugin add https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK.git --variable API_KEY_LIVE=value --variable API_KEY_TEST=value
 ```
-
-If you want to use NPM to manage your packages, the Branch Cordova SDK is also an NPM module.
-
+or Install latest version from npm
 ```sh
-npm install branch-cordova-sdk
+cordova plugin add branch-cordova-sdk --variable API_KEY_LIVE=value --variable API_KEY_TEST=value
 ```
-
 _____
 
-## Configure your app for deep linking
+### Register a URI Scheme
+Install Custom URL scheme Plugin by [Eddy Verbruggen](https://github.com/EddyVerbruggen/Custom-URL-scheme)
+
+```sh
+cordova plugin add cordova-plugin-customurlscheme --variable URL_SCHEME=mycoolapp
+```
+_____
+
+### iOS: Enable Universal Links
+Install Cordova Universal Links Plugin by [nordnet](https://github.com/nordnet/cordova-universal-links-plugin)
+
+```sh
+cordova plugin add cordova-universal-links-plugin
+```
+
+Add `bnc.lt` and your other hosts into `config.xml`:
+
+ ```xml
+ <universal-links>
+   <host name="bnc.lt" />
+   <host name="yourdomain.com" />
+ </universal-links>
+ ```
+
+ For test purpose you can leave only `bnc.lt` in there. But if you specifying your hosts - you need to [white label](https://dev.branch.io/recipes/branch_universal_links/#white-label-domains) them.
+
+
+ _____
+
+## Manually configure your app for deep linking
 
 ### Android: Register a URI Scheme and add your Branch key
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,17 @@
 		<clobbers target="branch" />
 		<clobbers target="Branch" />
 	</js-module>
+	<preference name="API_KEY_LIVE" />
+	<preference name="API_KEY_TEST" />
 	<platform name="ios">
+		<config-file target="*-Info.plist" parent="branch_key">
+			<dict>
+				<key>live</key>
+				<string>$API_KEY_LIVE</string>
+				<key>test</key>
+				<string>$API_KEY_TEST</string>
+			</dict>
+    </config-file>
 		<config-file target="config.xml" parent="/*">
 			<feature name="BranchDevice">
 				<param name="ios-package" value="BNCDevice" />
@@ -21,6 +31,10 @@
 		<source-file src="cordova-src/ios/BNCDevice.m" />
 	</platform>
 	<platform name="android">
+		<config-file target="AndroidManifest.xml" parent="/manifest/application/">
+				<meta-data android:name="io.branch.sdk.BranchKey" android:value="$API_KEY_LIVE" />
+				<meta-data android:name="io.branch.sdk.BranchKey.test" android:value="$API_KEY_TEST" />
+		</config-file>
 		<config-file target="config.xml" parent="/*">
 			<feature name="BranchDevice">
 				<param name="android-package" value="io.branch.BranchDevice"/>


### PR DESCRIPTION
API keys can be set using cordova cli while installing plugin and its easier to set custom URI scheme using https://github.com/EddyVerbruggen/Custom-URL-scheme , configure iOS 9.0 universal links using https://github.com/nordnet/cordova-universal-links-plugin