### PR TITLE
Make our object passed by DeepLinkHandler (iOS) actually an object

### DIFF
--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -98,7 +98,7 @@
             resultString = [NSString stringWithFormat:@"Init Error: %@", [error localizedDescription]];
         }
         NSLog(@"returning data to js interface..");
-        [self.commandDelegate evalJs:[NSString stringWithFormat:@"DeepLinkHandler('%@')", resultString]];
+        [self.commandDelegate evalJs:[NSString stringWithFormat:@"DeepLinkHandler(%@)", resultString]];
     }];
 }
 


### PR DESCRIPTION
For #52.

The object passed by the `DeepLinkHandler` handler, in JavaScript, should actually be an `Object`. Android currently passes an `Object` via the handler, and iOS returns a string due to quotes around the text. I simply removed these quotes to allow JavaScript to teach the data passed as an `Object`.

> Proposed Change Implementation Example
>  ```javascript
> // New
> function DeepLinkHandler(data) {
>     // Do stuff with data here 
> }
>
> // Current
> function DeepLinkHandler(data) {
>     if(typeof data === 'string') {
>         data = JSON.parse(string);
>     }
> 
>     // Do stuff with data here 
> }
> ```

_I have yet to actually test this... I'm not set up in my environment currently... so don't merge till someone tests_