### PR TITLE
Fix/pr 74 outstanding issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,15 @@ The Branch iOS SDK includes a wrapper on the UIActivityViewController, that will
 | $blackberry_url    | `string` | The URL for Blackberry
 | $windows_phone_url | `string` | The URL for Windows phone
 
+**callbacks**: `object` - Callback methods for share sheet
+
+|          KEY          |    TYPE    |      MEANING
+| --------------------- | ---------- | --------------------
+| onShareSheetDismissed | `function` | Callback listener for `onShareSheetDismissed`
+| onShareSheetDismissed | `function` | Callback listener for `onShareSheetLaunched`
+| onLinkShareResponse   | `function` | Callback listener for `onLinkShareResponse`
+| onChannelSelected     | `function` | Callback listener for `onChannelSelected`
+
 ##### Usage
 ```js
 branchUniversalObj.showShareSheet({
@@ -404,50 +413,19 @@ branchUniversalObj.showShareSheet({
 }, {
   // put your control parameters here
   "$desktop_url" : "http://desktop-url.com",
-});
-```
-
-##### Share Sheet Callbacks (Android ONLY)
-
-To implement the callback, you must add listeners to the following events:
-
-###### onShareSheetLaunched
-
-The event fires when the share sheet is presented.
-
-```js
-branchUniversalObj.onShareSheetLaunched(function () {
-  console.log('Share sheet launched');
-});
-```
-
-###### onShareSheetDismissed
-
-The event fires when the share sheet is dismissed.
-
-```js
-branchUniversalObj.onShareSheetDismissed(function () {
-  console.log('Share sheet dimissed');
-});
-```
-
-###### onLinkShareResponse
-
-The event returns a dictionary of the response data.
-
-```js
-branchUniversalObj.onLinkShareResponse(function (res) {
-  console.log('Share link response: ' + JSON.stringify(res));
-});
-```
-
-###### onChannelSelected
-
-The event fires when a channel is selected.
-
-```js
-branchUniversalObj.onChannelSelected(function (res) {
-  console.log('Channel selected: ' + JSON.stringify(res));
+}, {
+  onShareSheetLaunched: function() {
+      console.log('Share sheet launched');
+  },
+  onShareSheetDismissed: function() {
+      console.log('Share sheet dimissed');
+  },
+  onLinkShareResponse: function(res) {
+      console.log('Share link response: ' + JSON.stringify(res));
+  },
+  onChannelSelected: function(res) {
+      console.log('Channel selected: ' + JSON.stringify(res));
+  }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -408,15 +408,6 @@ The Branch iOS SDK includes a wrapper on the UIActivityViewController, that will
 | $blackberry_url    | `string` | The URL for Blackberry
 | $windows_phone_url | `string` | The URL for Windows phone
 
-**callbacks**: `object` - Callback methods for share sheet
-
-|          KEY          |    TYPE    |      MEANING
-| --------------------- | ---------- | --------------------
-| onShareSheetDismissed | `function` | Callback listener for `onShareSheetDismissed`
-| onShareSheetDismissed | `function` | Callback listener for `onShareSheetLaunched`
-| onLinkShareResponse   | `function` | Callback listener for `onLinkShareResponse`
-| onChannelSelected     | `function` | Callback listener for `onChannelSelected`
-
 ##### Usage
 ```js
 branchUniversalObj.showShareSheet({
@@ -428,21 +419,53 @@ branchUniversalObj.showShareSheet({
 }, {
   // put your control parameters here
   "$desktop_url" : "http://desktop-url.com",
-}, {
-  onShareSheetLaunched: function() {
-      console.log('Share sheet launched');
-  },
-  onShareSheetDismissed: function() {
-      console.log('Share sheet dimissed');
-  },
-  onLinkShareResponse: function(res) {
-      console.log('Share link response: ' + JSON.stringify(res));
-  },
-  onChannelSelected: function(res) {
-      console.log('Channel selected: ' + JSON.stringify(res));
-  }
 });
 ```
+
+##### Share Sheet Callbacks (Android ONLY)
+
+**NOTE: Share sheet callbacks must be declared first before executing `showShareSheet` or else it won't be able to catch the `event's first trigger`.**
+
+To implement the callback, you must add listeners to the following events:
+
+###### onShareSheetLaunched
+
+The event fires when the share sheet is presented.
+
+```js
+branchUniversalObj.onShareSheetLaunched(function () {
+  console.log('Share sheet launched');
+});
+```
+
+###### onShareSheetDismissed   
+    
+The event fires when the share sheet is dismissed.    
+    
+```js   
+branchUniversalObj.onShareSheetDismissed(function () {    
+  console.log('Share sheet dimissed');    
+});   
+```   
+    
+###### onLinkShareResponse    
+    
+The event returns a dictionary of the response data.    
+    
+```js   
+branchUniversalObj.onLinkShareResponse(function (res) {   
+  console.log('Share link response: ' + JSON.stringify(res));   
+});   
+```   
+    
+###### onChannelSelected    
+    
+The event fires when a channel is selected.   
+    
+```js   
+branchUniversalObj.onChannelSelected(function (res) {   
+  console.log('Channel selected: ' + JSON.stringify(res));    
+});
 
 **Note:** Callbacks in iOS are ignored. There is no need to implement them as the events are handled by `UIActivityViewController`.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ There's a full demo app embedded in this repository. It should serve as an examp
 ## Installation
 
 **The compiled iOS SDK footprint is 180kb**
+
 **The compiled Android SDK footprint is 187kb**
+
+**Latest libraries for [Android](http://developer.android.com/sdk/index.html) and/or iOS SDKs must be installed.**
 
 ### Command link install
 
@@ -122,6 +125,8 @@ Branch.getFirstReferringParams().then(function (res) {
   + [loadRewards](#loadRewards)
   + [redeemRewards](#redeemRewards)
   + [creditHistory](#creditHistory)
+4. FAQ
+  + [Android Build FAQ](#android-build-faq)
 
 
 ### <a id="setDebug"></a>setDebug(isEnable)
@@ -524,6 +529,16 @@ Branch.creditHistory().then(function (history) {
 The response will return an array that has been parsed from the following JSON:
 
 ```js
+
+## <a id="android-build-faq"></a>Android Build FAQ
+
+1. Gradle build cannot find `io.branch.sdk.android:library:1.+` dependency:
+
+Go to your `build.gradle` file and find **dependencies** and add the following inside:
+
+```
+compile "io.branch.sdk.android:library:1.+"
+```
 
 ## Bugs / Help / Support
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -70,7 +70,7 @@ SOFTWARE.
             </intent-filter>
         </config-file>
         <source-file src="src/android/io/branch/BranchSDK.java" target-dir="src/io/branch" />
-        <framework src="io.branch.sdk.android:library:1.+" />
+        <framework src="io.branch.sdk.android:library:1.+" custom="true" type="gradleReference" />
     </platform>
 
     <!-- ios -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -70,8 +70,7 @@ SOFTWARE.
             </intent-filter>
         </config-file>
         <source-file src="src/android/io/branch/BranchSDK.java" target-dir="src/io/branch" />
-        <framework src="io.branch.sdk.android:library:1.+" custom="true" />
-        <framework src="com.android.support:appcompat-v7:21+" />
+        <framework src="io.branch.sdk.android:library:1.+" />
     </platform>
 
     <!-- ios -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -70,7 +70,8 @@ SOFTWARE.
             </intent-filter>
         </config-file>
         <source-file src="src/android/io/branch/BranchSDK.java" target-dir="src/io/branch" />
-        <framework src="io.branch.sdk.android:library:1.+" custom="true" type="gradleReference" />
+        <framework src="io.branch.sdk.android:library:1.+" custom="true" />
+        <framework src="com.android.support:appcompat-v7:21+" />
     </platform>
 
     <!-- ios -->

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -177,6 +177,8 @@ public class BranchSDK extends CordovaPlugin
                     this.onChannelSelected = callbackContext;
                     return true;
                 }
+            } else {
+                callbackContext.error("Branch instance not set. Please execute initSession() first.");
             }
         }
 
@@ -242,8 +244,7 @@ public class BranchSDK extends CordovaPlugin
      * @param count A {@link Integer} specifying the number of credits to attempt to redeem from
      *              the bucket.
      */
-    private void redeemRewards(int value, String bucket)
-    {
+    private void redeemRewards(int value, String bucket) {
 
         Log.d(LCAT, "start redeemRewards()");
 

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -30,7 +30,7 @@ public class BranchSDK extends CordovaPlugin
     private static final String LCAT = "CordovaBranchSDK";
 
     // Private Method Properties
-    private ArrayList<BranchUniversalWrapper> branchObjectWrappers;
+    private ArrayList<BranchUniversalObjectWrapper> branchObjectWrappers;
     private Activity activity;
     private Branch instance;
 
@@ -41,7 +41,7 @@ public class BranchSDK extends CordovaPlugin
     {
         this.activity = null;
         this.instance = null;
-        this.branchObjectWrappers = new ArrayList<BranchUniversalWrapper>();
+        this.branchObjectWrappers = new ArrayList<BranchUniversalObjectWrapper>();
     }
 
     /**
@@ -196,28 +196,28 @@ public class BranchSDK extends CordovaPlugin
                     }
                 } else if (action.equals("onShareLinkDialogLaunched")) {
 
-                    BranchUniversalWrapper branchObjWrapper = (BranchUniversalWrapper)branchObjectWrappers.get(args.getInt(0));
+                    BranchUniversalObjectWrapper branchObjWrapper = (BranchUniversalObjectWrapper)branchObjectWrappers.get(args.getInt(0));
                                            branchObjWrapper.onShareLinkDialogLaunched = callbackContext;
 
                     branchObjectWrappers.set(args.getInt(0), branchObjWrapper);
 
                 } else if (action.equals("onShareLinkDialogDismissed")) {
 
-                    BranchUniversalWrapper branchObjWrapper = (BranchUniversalWrapper)branchObjectWrappers.get(args.getInt(0));
+                    BranchUniversalObjectWrapper branchObjWrapper = (BranchUniversalObjectWrapper)branchObjectWrappers.get(args.getInt(0));
                                            branchObjWrapper.onShareLinkDialogDismissed = callbackContext;
 
                     branchObjectWrappers.set(args.getInt(0), branchObjWrapper);
 
                 } else if (action.equals("onLinkShareResponse")) {
 
-                    BranchUniversalWrapper branchObjWrapper = (BranchUniversalWrapper)branchObjectWrappers.get(args.getInt(0));
+                    BranchUniversalObjectWrapper branchObjWrapper = (BranchUniversalObjectWrapper)branchObjectWrappers.get(args.getInt(0));
                                            branchObjWrapper.onLinkShareResponse = callbackContext;
 
                     branchObjectWrappers.set(args.getInt(0), branchObjWrapper);
 
                 } else if (action.equals("onChannelSelected")) {
 
-                    BranchUniversalWrapper branchObjWrapper = (BranchUniversalWrapper)branchObjectWrappers.get(args.getInt(0));
+                    BranchUniversalObjectWrapper branchObjWrapper = (BranchUniversalObjectWrapper)branchObjectWrappers.get(args.getInt(0));
                                            branchObjWrapper.onChannelSelected = callbackContext;
 
                     branchObjectWrappers.set(args.getInt(0), branchObjWrapper);
@@ -444,7 +444,7 @@ public class BranchSDK extends CordovaPlugin
             }
         }
 
-        BranchUniversalWrapper branchObjWrapper = new BranchUniversalWrapper(branchObj);
+        BranchUniversalObjectWrapper branchObjWrapper = new BranchUniversalObjectWrapper(branchObj);
 
         this.branchObjectWrappers.add(branchObjWrapper);
         JSONObject response = new JSONObject();
@@ -475,7 +475,7 @@ public class BranchSDK extends CordovaPlugin
                 .addPreferredSharingOption(SharingHelper.SHARE_WITH.FACEBOOK)
                 .addPreferredSharingOption(SharingHelper.SHARE_WITH.EMAIL);
 
-        BranchUniversalWrapper branchObjWrapper = (BranchUniversalWrapper)this.branchObjectWrappers.get(instanceIdx);
+        BranchUniversalObjectWrapper branchObjWrapper = (BranchUniversalObjectWrapper)this.branchObjectWrappers.get(instanceIdx);
         BranchLinkProperties linkProperties = createLinkProperties(options, controlParams);
         BranchUniversalObject branchObj = branchObjWrapper.branchUniversalObj;
 
@@ -566,7 +566,7 @@ public class BranchSDK extends CordovaPlugin
 
         Log.d(LCAT, "start registerView()");
 
-        BranchUniversalWrapper branchUniversalWrapper = (BranchUniversalWrapper)this.branchObjectWrappers.get(instanceIdx);
+        BranchUniversalObjectWrapper branchUniversalWrapper = (BranchUniversalObjectWrapper)this.branchObjectWrappers.get(instanceIdx);
 
         branchUniversalWrapper.branchUniversalObj.registerView(new RegisterViewStatusListener(callbackContext));
 
@@ -639,7 +639,7 @@ public class BranchSDK extends CordovaPlugin
             linkProperties.addControlParameter("$windows_phone_url", controlParams.getString("$windows_phone_url"));
         }
 
-        BranchUniversalWrapper branchUniversalWrapper = (BranchUniversalWrapper) this.branchObjectWrappers.get(instanceIdx);
+        BranchUniversalObjectWrapper branchUniversalWrapper = (BranchUniversalObjectWrapper) this.branchObjectWrappers.get(instanceIdx);
 
         branchUniversalWrapper.branchUniversalObj.generateShortUrl(this.activity, linkProperties, new GenerateShortUrlListener(callbackContext));
 
@@ -738,9 +738,9 @@ public class BranchSDK extends CordovaPlugin
     /**
      * @access protected
      *
-     * @class BranchUniversalWrapper
+     * @class BranchUniversalObjectWrapper
      */
-    protected class BranchUniversalWrapper
+    protected class BranchUniversalObjectWrapper
     {
 
         public BranchUniversalObject branchUniversalObj;
@@ -754,7 +754,7 @@ public class BranchSDK extends CordovaPlugin
          *
          * @param BranchUniversalObject branchUniversalObj
          */
-        public BranchUniversalWrapper(BranchUniversalObject branchUniversalObj) {
+        public BranchUniversalObjectWrapper(BranchUniversalObject branchUniversalObj) {
             this.branchUniversalObj = branchUniversalObj;
             this.onShareLinkDialogDismissed = null;
             this.onShareLinkDialogLaunched = null;
@@ -1026,6 +1026,10 @@ public class BranchSDK extends CordovaPlugin
         public void onShareLinkDialogLaunched() {
             Log.d(LCAT, "inside onShareLinkDialogLaunched");
 
+            if (_onShareLinkDialogLaunched == null) {
+                return;
+            }
+
             PluginResult result = new PluginResult(PluginResult.Status.OK);
 
             result.setKeepCallback(true);
@@ -1037,6 +1041,10 @@ public class BranchSDK extends CordovaPlugin
         @Override
         public void onShareLinkDialogDismissed() {
             Log.d(LCAT, "inside onShareLinkDialogDismissed");
+
+            if (_onShareLinkDialogDismissed == null) {
+                return;
+            }
 
             PluginResult result = new PluginResult(PluginResult.Status.OK);
 
@@ -1050,6 +1058,10 @@ public class BranchSDK extends CordovaPlugin
         public void onLinkShareResponse(String sharedLink, String sharedChannel, BranchError error) {
 
             Log.d(LCAT, "inside onLinkCreate");
+
+            if (_onLinkShareResponse == null) {
+                return;
+            }
 
             JSONObject response = new JSONObject();
 
@@ -1093,6 +1105,10 @@ public class BranchSDK extends CordovaPlugin
 
             Log.d(LCAT, "inside onChannelSelected");
             Log.d(LCAT, "channelName: " + channelName);
+
+            if (_onChannelSelected == null) {
+                return;
+            }
 
             JSONObject response = new JSONObject();
 

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -178,7 +178,7 @@ public class BranchSDK extends CordovaPlugin
                     }
                 } else if (action.equals("registerView")) {
                     if (args.length() == 1) {
-                        this.registerView(args.getInt(0));
+                        this.registerView(args.getInt(0), callbackContext);
                     }
                     return true;
                 } else if (action.equals("showShareSheet")) {
@@ -521,14 +521,14 @@ public class BranchSDK extends CordovaPlugin
      *
      * @param instanceIdx The instance index from branchObjects array
      */
-    private void registerView(int instanceIdx)
+    private void registerView(int instanceIdx, CallbackContext callbackContext)
     {
 
         Log.d(LCAT, "start registerView()");
 
         BranchUniversalObject branchObj = (BranchUniversalObject)this.branchObjects.get(instanceIdx);
 
-        branchObj.registerView();
+        branchObj.registerView(new RegisterViewStatusListener(callbackContext));
 
     }
 

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -30,12 +30,7 @@ public class BranchSDK extends CordovaPlugin
     private static final String LCAT = "CordovaBranchSDK";
 
     // Private Method Properties
-    private ArrayList<BranchUniversalObject> branchObjects;
-    private CallbackContext callbackContext;
-    private CallbackContext onShareLinkDialogLaunched;
-    private CallbackContext onShareLinkDialogDismissed;
-    private CallbackContext onLinkShareResponse;
-    private CallbackContext onChannelSelected;
+    private ArrayList<BranchUniversalWrapper> branchObjectWrappers;
     private Activity activity;
     private Branch instance;
 
@@ -46,12 +41,7 @@ public class BranchSDK extends CordovaPlugin
     {
         this.activity = null;
         this.instance = null;
-        this.callbackContext = null;
-        this.onShareLinkDialogLaunched = null;
-        this.onShareLinkDialogDismissed = null;
-        this.onLinkShareResponse = null;
-        this.onChannelSelected = null;
-        this.branchObjects = new ArrayList<BranchUniversalObject>();
+        this.branchObjectWrappers = new ArrayList<BranchUniversalWrapper>();
     }
 
     /**
@@ -121,6 +111,7 @@ public class BranchSDK extends CordovaPlugin
             if (this.instance != null) {
                 if (action.equals("setIdentity")) {
                     this.setIdentity(args.getString(0), callbackContext);
+
                     return true;
                 } else if (action.equals("userCompletedAction")) {
                     if (args.length() < 1 && args.length() > 2) {
@@ -128,10 +119,11 @@ public class BranchSDK extends CordovaPlugin
                         return false;
                     }
                     if (args.length() == 2) {
-                        this.userCompletedAction (args.getString(0), args.getJSONObject(1));
+                        this.userCompletedAction(args.getString(0), args.getJSONObject(1), callbackContext);
                     } else if (args.length() == 1) {
-                        this.userCompletedAction(args.getString(0));
+                        this.userCompletedAction(args.getString(0), callbackContext);
                     }
+
                     return true;
                 } else if (action.equals("getFirstReferringParams")) {
                     this.getFirstReferringParams(callbackContext);
@@ -148,6 +140,7 @@ public class BranchSDK extends CordovaPlugin
                 } else if (action.equals("redeemRewards")) {
                     if (args.length() < 1 && args.length() > 2) {
                         callbackContext.error(String.format("Parameter mismatched. 1-2 is required but %d is given", args.length()));
+
                         return false;
                     }
                     if (args.length() == 1) {
@@ -155,52 +148,84 @@ public class BranchSDK extends CordovaPlugin
                     } else if (args.length() == 2) {
                         this.redeemRewards(args.getInt(0), args.getString(1), callbackContext);
                     }
+
                     return true;
                 } else if (action.equals("getCreditHistory")) {
                     this.getCreditHistory(callbackContext);
+
                     return true;
                 } else if (action.equals("createBranchUniversalObject")) {
                     if (args.length() == 1) {
                         this.createBranchUniversalObject(args.getJSONObject(0), callbackContext);
+
                         return true;
                     } else {
                         callbackContext.error(String.format("Parameter mismatched. 1 is required but %d is given", args.length()));
+
                         return false;
                     }
                 } else if (action.equals(("generateShortUrl"))) {
                     if (args.length() == 3) {
                         this.generateShortUrl(args.getInt(0), args.getJSONObject(1), args.getJSONObject(2), callbackContext);
+
                         return true;
                     } else {
                         callbackContext.error(String.format("Parameter mismatched. 3 is required but %d is given", args.length()));
+
                         return false;
                     }
                 } else if (action.equals("registerView")) {
                     if (args.length() == 1) {
                         this.registerView(args.getInt(0), callbackContext);
+
+                        return true;
+                    } else {
+                        callbackContext.error(String.format("Parameter mismatched. 1 is required but %d is given", args.length()));
+
+                        return false;
                     }
-                    return true;
                 } else if (action.equals("showShareSheet")) {
                     if (args.length() == 3) {
                         this.showShareSheet(args.getInt(0), args.getJSONObject(1), args.getJSONObject(2));
+
                         return true;
                     } else {
                         callbackContext.error(String.format("Parameter mismatched. 3 is required but %d is given", args.length()));
+
                         return false;
                     }
                 } else if (action.equals("onShareLinkDialogLaunched")) {
-                    this.onShareLinkDialogLaunched = callbackContext;
-                    return true;
+
+                    BranchUniversalWrapper branchObjWrapper = (BranchUniversalWrapper)branchObjectWrappers.get(args.getInt(0));
+                                           branchObjWrapper.onShareLinkDialogLaunched = callbackContext;
+
+                    branchObjectWrappers.set(args.getInt(0), branchObjWrapper);
+
                 } else if (action.equals("onShareLinkDialogDismissed")) {
-                    this.onShareLinkDialogDismissed = callbackContext;
-                    return true;
+
+                    BranchUniversalWrapper branchObjWrapper = (BranchUniversalWrapper)branchObjectWrappers.get(args.getInt(0));
+                                           branchObjWrapper.onShareLinkDialogDismissed = callbackContext;
+
+                    branchObjectWrappers.set(args.getInt(0), branchObjWrapper);
+
                 } else if (action.equals("onLinkShareResponse")) {
-                    this.onLinkShareResponse = callbackContext;
-                    return true;
+
+                    BranchUniversalWrapper branchObjWrapper = (BranchUniversalWrapper)branchObjectWrappers.get(args.getInt(0));
+                                           branchObjWrapper.onLinkShareResponse = callbackContext;
+
+                    branchObjectWrappers.set(args.getInt(0), branchObjWrapper);
+
                 } else if (action.equals("onChannelSelected")) {
-                    this.onChannelSelected = callbackContext;
-                    return true;
+
+                    BranchUniversalWrapper branchObjWrapper = (BranchUniversalWrapper)branchObjectWrappers.get(args.getInt(0));
+                                           branchObjWrapper.onChannelSelected = callbackContext;
+
+                    branchObjectWrappers.set(args.getInt(0), branchObjWrapper);
+
                 }
+
+                return true;
+
             } else {
                 callbackContext.error("Branch instance not set. Please execute initSession() first.");
             }
@@ -419,14 +444,16 @@ public class BranchSDK extends CordovaPlugin
             }
         }
 
-        this.branchObjects.add(branchObj);
+        BranchUniversalWrapper branchObjWrapper = new BranchUniversalWrapper(branchObj);
 
+        this.branchObjectWrappers.add(branchObjWrapper);
         JSONObject response = new JSONObject();
+                   response.put("message", "Success");
+                   response.put("branchUniversalObjectId", this.branchObjectWrappers.size() - 1);
 
-        response.put("message", "Success");
-        response.put("branchUniversalObjectId", this.branchObjects.size() - 1);
+        Log.d(LCAT, String.format("Branch wrapper size: %d", this.branchObjectWrappers.size()));
 
-        this.callbackContext.success(response);
+        callbackContext.success(response);
 
     }
 
@@ -448,11 +475,12 @@ public class BranchSDK extends CordovaPlugin
                 .addPreferredSharingOption(SharingHelper.SHARE_WITH.FACEBOOK)
                 .addPreferredSharingOption(SharingHelper.SHARE_WITH.EMAIL);
 
+        BranchUniversalWrapper branchObjWrapper = (BranchUniversalWrapper)this.branchObjectWrappers.get(instanceIdx);
         BranchLinkProperties linkProperties = createLinkProperties(options, controlParams);
+        BranchUniversalObject branchObj = branchObjWrapper.branchUniversalObj;
 
-        BranchUniversalObject branchObj = (BranchUniversalObject)this.branchObjects.get(instanceIdx);
-
-        branchObj.showShareSheet(this.activity, linkProperties, shareSheetStyle, new ShowShareSheetListener());
+        branchObj.showShareSheet(this.activity, linkProperties, shareSheetStyle,
+                                new ShowShareSheetListener(branchObjWrapper.onShareLinkDialogLaunched, branchObjWrapper.onShareLinkDialogDismissed, branchObjWrapper.onLinkShareResponse, branchObjWrapper.onChannelSelected));
 
     }
 
@@ -538,9 +566,9 @@ public class BranchSDK extends CordovaPlugin
 
         Log.d(LCAT, "start registerView()");
 
-        BranchUniversalObject branchObj = (BranchUniversalObject)this.branchObjects.get(instanceIdx);
+        BranchUniversalWrapper branchUniversalWrapper = (BranchUniversalWrapper)this.branchObjectWrappers.get(instanceIdx);
 
-        branchObj.registerView(new RegisterViewStatusListener(callbackContext));
+        branchUniversalWrapper.branchUniversalObj.registerView(new RegisterViewStatusListener(callbackContext));
 
     }
 
@@ -611,9 +639,9 @@ public class BranchSDK extends CordovaPlugin
             linkProperties.addControlParameter("$windows_phone_url", controlParams.getString("$windows_phone_url"));
         }
 
-        BranchUniversalObject branchObj = (BranchUniversalObject)this.branchObjects.get(instanceIdx);
+        BranchUniversalWrapper branchUniversalWrapper = (BranchUniversalWrapper) this.branchObjectWrappers.get(instanceIdx);
 
-        branchObj.generateShortUrl(this.activity, linkProperties, new GenerateShortUrlListener(callbackContext));
+        branchUniversalWrapper.branchUniversalObj.generateShortUrl(this.activity, linkProperties, new GenerateShortUrlListener(callbackContext));
 
     }
 
@@ -704,6 +732,35 @@ public class BranchSDK extends CordovaPlugin
         Log.d(LCAT, "start creditHistory()");
 
         this.instance.getCreditHistory(new CreditHistoryListener(callbackContext));
+
+    }
+
+    /**
+     * @access protected
+     *
+     * @class BranchUniversalWrapper
+     */
+    protected class BranchUniversalWrapper
+    {
+
+        public BranchUniversalObject branchUniversalObj;
+        public CallbackContext onShareLinkDialogDismissed;
+        public CallbackContext onShareLinkDialogLaunched;
+        public CallbackContext onLinkShareResponse;
+        public CallbackContext onChannelSelected;
+
+        /**
+         * @constructor
+         *
+         * @param BranchUniversalObject branchUniversalObj
+         */
+        public BranchUniversalWrapper(BranchUniversalObject branchUniversalObj) {
+            this.branchUniversalObj = branchUniversalObj;
+            this.onShareLinkDialogDismissed = null;
+            this.onShareLinkDialogLaunched = null;
+            this.onLinkShareResponse = null;
+            this.onChannelSelected = null;
+        }
 
     }
 
@@ -892,7 +949,9 @@ public class BranchSDK extends CordovaPlugin
 
         // Constructor that takes in a required callbackContext object
         public GenerateShortUrlListener(CallbackContext callbackContext) {
+
             this._callbackContext = callbackContext;
+
         }
 
         @Override
@@ -940,17 +999,38 @@ public class BranchSDK extends CordovaPlugin
 
     protected class ShowShareSheetListener implements Branch.BranchLinkShareListener
     {
+
+        private CallbackContext _onShareLinkDialogLaunched;
+        private CallbackContext _onShareLinkDialogDismissed;
+        private CallbackContext _onLinkShareResponse;
+        private CallbackContext _onChannelSelected;
+
+        /**
+         * @constructor
+         *
+         * @param CallbackContext onShareLinkDialogLaunched
+         * @param CallbackContext onShareLinkDialogDismissed
+         * @param CallbackContext onLinkShareResponse
+         * @param CallbackContext onChannelSelected
+         * */
+        public ShowShareSheetListener(CallbackContext onShareLinkDialogLaunched, CallbackContext onShareLinkDialogDismissed, CallbackContext onLinkShareResponse, CallbackContext onChannelSelected) {
+
+            this._onShareLinkDialogDismissed = onShareLinkDialogDismissed;
+            this._onShareLinkDialogLaunched = onShareLinkDialogLaunched;
+            this._onLinkShareResponse = onLinkShareResponse;
+            this._onChannelSelected = onChannelSelected;
+
+        }
+
         @Override
         public void onShareLinkDialogLaunched() {
             Log.d(LCAT, "inside onShareLinkDialogLaunched");
 
-            if (onShareLinkDialogLaunched != null) {
-                PluginResult result = new PluginResult(PluginResult.Status.OK);
+            PluginResult result = new PluginResult(PluginResult.Status.OK);
 
-                result.setKeepCallback(true);
+            result.setKeepCallback(true);
 
-                onShareLinkDialogLaunched.sendPluginResult(result);
-            }
+            this._onShareLinkDialogLaunched.sendPluginResult(result);
 
         }
 
@@ -958,13 +1038,11 @@ public class BranchSDK extends CordovaPlugin
         public void onShareLinkDialogDismissed() {
             Log.d(LCAT, "inside onShareLinkDialogDismissed");
 
-            if (onShareLinkDialogDismissed != null) {
-                PluginResult result = new PluginResult(PluginResult.Status.OK);
+            PluginResult result = new PluginResult(PluginResult.Status.OK);
 
-                result.setKeepCallback(true);
+            result.setKeepCallback(true);
 
-                onShareLinkDialogDismissed.sendPluginResult(result);
-            }
+            this._onShareLinkDialogDismissed.sendPluginResult(result);
 
         }
 
@@ -1002,13 +1080,11 @@ public class BranchSDK extends CordovaPlugin
 
             Log.d(LCAT, response.toString());
 
-            if (onLinkShareResponse != null) {
-                PluginResult result = new PluginResult(PluginResult.Status.OK, response);
+            PluginResult result = new PluginResult(PluginResult.Status.OK, response);
 
-                result.setKeepCallback(true);
+            result.setKeepCallback(true);
 
-                onLinkShareResponse.sendPluginResult(result);
-            }
+            this._onLinkShareResponse.sendPluginResult(result);
 
         }
 
@@ -1029,13 +1105,11 @@ public class BranchSDK extends CordovaPlugin
 
             Log.d(LCAT, response.toString());
 
-            if (onChannelSelected != null) {
-                PluginResult result = new PluginResult(PluginResult.Status.OK, response);
+            PluginResult result = new PluginResult(PluginResult.Status.OK, response);
 
-                result.setKeepCallback(true);
+            result.setKeepCallback(true);
 
-                onChannelSelected.sendPluginResult(result);
-            }
+            this._onChannelSelected.sendPluginResult(result);
 
         }
     }

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -124,9 +124,13 @@ public class BranchSDK extends CordovaPlugin
                     this.setIdentity(args.getString(0));
                     return true;
                 } else if (action.equals("userCompletedAction")) {
+                    if (args.length() < 1 && args.length() > 2) {
+                        callbackContext.error(String.format("Parameter mismatched. 1-2 is required but %d is given", args.length()));
+                        return false;
+                    }
                     if (args.length() == 2) {
                         this.userCompletedAction (args.getString(0), args.getJSONObject(1));
-                    } else {
+                    } else if (args.length() == 1) {
                         this.userCompletedAction(args.getString(0));
                     }
                     return true;
@@ -143,6 +147,10 @@ public class BranchSDK extends CordovaPlugin
                     this.loadRewards();
                     return true;
                 } else if (action.equals("redeemRewards")) {
+                    if (args.length() < 1 && args.length() > 2) {
+                        callbackContext.error(String.format("Parameter mismatched. 1-2 is required but %d is given", args.length()));
+                        return false;
+                    }
                     if (args.length() == 1) {
                         this.redeemRewards(args.getInt(0));
                     } else if (args.length() == 2) {
@@ -155,13 +163,19 @@ public class BranchSDK extends CordovaPlugin
                 } else if (action.equals("createBranchUniversalObject")) {
                     if (args.length() == 1) {
                         this.createBranchUniversalObject(args.getJSONObject(0));
+                        return true;
+                    } else {
+                        callbackContext.error(String.format("Parameter mismatched. 1 is required but %d is given", args.length()));
+                        return false;
                     }
-                    return true;
                 } else if (action.equals(("generateShortUrl"))) {
                     if (args.length() == 3) {
                         this.generateShortUrl(args.getInt(0), args.getJSONObject(1), args.getJSONObject(2));
+                        return true;
+                    } else {
+                        callbackContext.error(String.format("Parameter mismatched. 3 is required but %d is given", args.length()));
+                        return false;
                     }
-                    return true;
                 } else if (action.equals("registerView")) {
                     if (args.length() == 1) {
                         this.registerView(args.getInt(0));
@@ -170,8 +184,11 @@ public class BranchSDK extends CordovaPlugin
                 } else if (action.equals("showShareSheet")) {
                     if (args.length() == 3) {
                         this.showShareSheet(args.getInt(0), args.getJSONObject(1), args.getJSONObject(2));
+                        return true;
+                    } else {
+                        callbackContext.error(String.format("Parameter mismatched. 3 is required but %d is given", args.length()));
+                        return false;
                     }
-                    return true;
                 } else if (action.equals("onShareLinkDialogLaunched")) {
                     this.onShareLinkDialogLaunched = callbackContext;
                     return true;
@@ -395,7 +412,7 @@ public class BranchSDK extends CordovaPlugin
         JSONObject response = new JSONObject();
 
         response.put("message", "Success");
-        response.put("instance", this.branchObjects.size() - 1);
+        response.put("branchUniversalObjectId", this.branchObjects.size() - 1);
 
         this.callbackContext.success(response);
 

--- a/testbed/www/js/index.js
+++ b/testbed/www/js/index.js
@@ -230,22 +230,22 @@ function ShowShareSheet()
         $blackberry_url: 'blackberry',
         $windows_phone_url: 'win-phone'
     };
+    var callbacks = {
+        onShareSheetLaunched: function() {
+            console.log('Share sheet launched');
+        },
+        onShareSheetDismissed: function() {
+            console.log('Share sheet dimissed');
+        },
+        onLinkShareResponse: function(res) {
+            console.log('Share link response: ' + JSON.stringify(res));
+        },
+        onChannelSelected: function(res) {
+            console.log('Channel selected: ' + JSON.stringify(res));
+        }
+    };
 
-    branchUniversalObj.showShareSheet(properties, controlParams);
-
-    // Set listeners
-    branchUniversalObj.onShareSheetLaunched(function () {
-        console.log('Share sheet launched');
-    });
-    branchUniversalObj.onShareSheetDismissed(function () {
-      console.log('Share sheet dimissed');
-    });
-    branchUniversalObj.onLinkShareResponse(function (res) {
-      console.log('Share link response: ' + JSON.stringify(res));
-    });
-    branchUniversalObj.onChannelSelected(function (res) {
-      console.log('Channel selected: ' + JSON.stringify(res));
-    });
+    branchUniversalObj.showShareSheet(properties, controlParams, callbacks);
     
 }
 

--- a/testbed/www/js/index.js
+++ b/testbed/www/js/index.js
@@ -230,23 +230,25 @@ function ShowShareSheet()
         $blackberry_url: 'blackberry',
         $windows_phone_url: 'win-phone'
     };
-    var callbacks = {
-        onShareSheetLaunched: function() {
-            console.log('Share sheet launched');
-        },
-        onShareSheetDismissed: function() {
-            console.log('Share sheet dimissed');
-        },
-        onLinkShareResponse: function(res) {
-            console.log('Share link response: ' + JSON.stringify(res));
-        },
-        onChannelSelected: function(res) {
-            console.log('Channel selected: ' + JSON.stringify(res));
-        }
-    };
 
-    branchUniversalObj.showShareSheet(properties, controlParams, callbacks);
-    
+    console.log(branchUniversalObj);
+
+    // Set listeners       
+    branchUniversalObj.onShareSheetLaunched(function () {     
+        console.log('Share sheet launched');      
+    });
+    branchUniversalObj.onShareSheetDismissed(function () {        
+      console.log('Share sheet dimissed');        
+    });
+    branchUniversalObj.onLinkShareResponse(function (res) {       
+      console.log('Share link response: ' + JSON.stringify(res));     
+    });
+    branchUniversalObj.onChannelSelected(function (res) {     
+      console.log('Channel selected: ' + JSON.stringify(res));        
+    });
+
+    branchUniversalObj.showShareSheet(properties, controlParams);
+
 }
 
 function ListOnSpotlight()

--- a/www/branch.js
+++ b/www/branch.js
@@ -176,10 +176,11 @@ Branch.prototype.userCompletedAction = function (action, metaData) {
 Branch.prototype.createBranchUniversalObject = function (options) {
 
     return new Promise(function (resolve, reject) {
-        execute('createBranchUniversalObject', [options]).then(function () {
+        execute('createBranchUniversalObject', [options]).then(function (res) {
 
-            var res = {
-                message: 'success'
+            var obj = {
+                message: res.message,
+                instanceIdx: res.instance
             };
 
             // Attach object functions
@@ -188,8 +189,10 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              *
              * @return (Promise)
              */
-            res.registerView = function () {
-                return execute('registerView');
+            obj.registerView = function () {
+
+                return execute('registerView', [obj.instanceIdx]);
+
             };
 
             /**
@@ -225,9 +228,9 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              *    | $windows_phone_url |   String   |  Kindle Fire URL  |
              *    -------------------------------------------------------
              */
-            res.generateShortUrl = function (options, controlParameters) {
+            obj.generateShortUrl = function (options, controlParameters) {
 
-                return execute('generateShortUrl', [options, controlParameters]);
+                return execute('generateShortUrl', [obj.instanceIdx, options, controlParameters]);
 
             };
 
@@ -264,9 +267,9 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              *    | $windows_phone_url |   String   |  Kindle Fire URL  |
              *    -------------------------------------------------------
              */
-            res.showShareSheet = function (options, controlParameters) {
+            obj.showShareSheet = function (options, controlParameters) {
 
-                return execute('showShareSheet', [options, controlParameters]);
+                return execute('showShareSheet', [obj.instanceIdx, options, controlParameters]);
 
             };
 
@@ -275,7 +278,7 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              *
              * @param (Function) callback
              */
-            res.onShareSheetLaunched = function (callback) {
+            obj.onShareSheetLaunched = function (callback) {
 
                 executeCallback('onShareLinkDialogLaunched', callback);
 
@@ -286,7 +289,7 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              *
              * @param (Function) callback
              */
-            res.onShareSheetDismissed = function (callback) {
+            obj.onShareSheetDismissed = function (callback) {
 
                 executeCallback('onShareLinkDialogDismissed', callback);
 
@@ -297,7 +300,7 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              *
              * @param (Function) callback
              */
-            res.onLinkShareResponse = function (callback) {
+            obj.onLinkShareResponse = function (callback) {
 
                 executeCallback('onLinkShareResponse', callback);
 
@@ -308,7 +311,7 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              *
              * @param (Function) callback
              */
-            res.onChannelSelected = function (callback) {
+            obj.onChannelSelected = function (callback) {
 
                 executeCallback('onChannelSelected', callback);
 
@@ -317,11 +320,11 @@ Branch.prototype.createBranchUniversalObject = function (options) {
             /**
              * List item on Spotlight (iOS Only).
              */
-            res.listOnSpotlight = function () {
+            obj.listOnSpotlight = function () {
                 return execute('listOnSpotlight');
             };
 
-            resolve(res);
+            resolve(obj);
 
         }, function (err) {
             reject(err);

--- a/www/branch.js
+++ b/www/branch.js
@@ -35,14 +35,17 @@ function execute(method, params) {
  *
  * @param  (String) method      - The class method to execute.
  * @param  (Function) callback  - The method listener callback.
+ * @param  (Array) params       - The method listener parameters.
  *
  * @return (Promise)
  */
-function executeCallback(method, callback) {
+function executeCallback(method, callback, params) {
+
+    params = ( ! params) ? [] : params;
 
     exec(callback, function (err) {
         console.error(err);
-    }, _API_CLASS, method, []);
+    }, _API_CLASS, method, params);
 
 }
 
@@ -239,6 +242,7 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              *
              * @param (Object) options
              * @param (Object) controlParameters
+             * @param (Object) callbacks
              *
              * @return (Promise)
              *
@@ -266,57 +270,43 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              *    |  $blackberry_url   |   String   |   Blackberry URL  |
              *    | $windows_phone_url |   String   |  Kindle Fire URL  |
              *    -------------------------------------------------------
+             *
+             * callbacks: 
+             *    -----------------------------------------------------------------------------------------------
+             *    |             KEY            |     TYPE     |                    DESCRIPTION                  |
+             *    -----------------------------------------------------------------------------------------------
+             *    |    onShareSheetDismissed   |   Function   |  Callback listener for `onShareSheetDismissed`  |
+             *    |    onShareSheetDismissed   |   Function   |  Callback listener for `onShareSheetLaunched`   |
+             *    |     onLinkShareResponse    |   Function   |  Callback listener for `onLinkShareResponse`    |
+             *    |      onChannelSelected     |   Function   |  Callback listener for `onChannelSelected`      |
+             *    -----------------------------------------------------------------------------------------------
              */
-            obj.showShareSheet = function (options, controlParameters) {
+            obj.showShareSheet = function (options, controlParameters, callbacks) {
+
+                // If no callback set, we'll default it to an empty function
+                if ( ! callbacks.onShareSheetDismissed) {
+                    callbacks.onShareSheetDismissed = function () {};
+                }
+                if ( ! callbacks.onShareSheetLaunched) {
+                    callbacks.onShareSheetLaunched = function () {};
+                }
+                if ( ! callbacks.onLinkShareResponse) {
+                    callbacks.onLinkShareResponse = function () {};
+                }
+                if ( ! callbacks.onChannelSelected) {
+                    callbacks.onChannelSelected = function () {};
+                }
+
+                // Set listener callbacks
+                executeCallback('onShareLinkDialogDismissed', callbacks.onShareSheetDismissed, [obj.instanceId]);
+                executeCallback('onShareLinkDialogLaunched', callbacks.onShareSheetLaunched, [obj.instanceId]);
+                executeCallback('onLinkShareResponse', callbacks.onLinkShareResponse, [obj.instanceId]);
+                executeCallback('onChannelSelected', callbacks.onChannelSelected, [obj.instanceId]);
 
                 return execute('showShareSheet', [obj.instanceId, options, controlParameters]);
 
             };
-
-            /**
-             * Set on share sheet launched listener callback.
-             *
-             * @param (Function) callback
-             */
-            obj.onShareSheetLaunched = function (callback) {
-
-                executeCallback('onShareLinkDialogLaunched', callback);
-
-            };
-
-            /**
-             * Set on share sheet dismissed listener callback.
-             *
-             * @param (Function) callback
-             */
-            obj.onShareSheetDismissed = function (callback) {
-
-                executeCallback('onShareLinkDialogDismissed', callback);
-
-            };
-
-            /**
-             * Set on link share listener callback.
-             *
-             * @param (Function) callback
-             */
-            obj.onLinkShareResponse = function (callback) {
-
-                executeCallback('onLinkShareResponse', callback);
-
-            };
-
-            /**
-             * Set on channel select listener callback.
-             *
-             * @param (Function) callback
-             */
-            obj.onChannelSelected = function (callback) {
-
-                executeCallback('onChannelSelected', callback);
-
-            };
-
+            
             /**
              * List item on Spotlight (iOS Only).
              */

--- a/www/branch.js
+++ b/www/branch.js
@@ -53,7 +53,9 @@ function executeCallback(method, callback, params) {
  * @class Branch
  */
 var Branch = function () {
+    
     this.debugMode = false;
+
 };
 
 /**
@@ -62,7 +64,9 @@ var Branch = function () {
  * @return (Promise)
  */
 Branch.prototype.initSession = function () {
+    
     return execute('initSession');
+
 };
 
 /**

--- a/www/branch.js
+++ b/www/branch.js
@@ -180,7 +180,7 @@ Branch.prototype.createBranchUniversalObject = function (options) {
 
             var obj = {
                 message: res.message,
-                instanceIdx: res.instance
+                instanceId: res.branchUniversalObjectId
             };
 
             // Attach object functions
@@ -191,7 +191,7 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              */
             obj.registerView = function () {
 
-                return execute('registerView', [obj.instanceIdx]);
+                return execute('registerView', [obj.instanceId]);
 
             };
 
@@ -230,7 +230,7 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              */
             obj.generateShortUrl = function (options, controlParameters) {
 
-                return execute('generateShortUrl', [obj.instanceIdx, options, controlParameters]);
+                return execute('generateShortUrl', [obj.instanceId, options, controlParameters]);
 
             };
 
@@ -269,7 +269,7 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              */
             obj.showShareSheet = function (options, controlParameters) {
 
-                return execute('showShareSheet', [obj.instanceIdx, options, controlParameters]);
+                return execute('showShareSheet', [obj.instanceId, options, controlParameters]);
 
             };
 

--- a/www/branch.js
+++ b/www/branch.js
@@ -246,7 +246,6 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              *
              * @param (Object) options
              * @param (Object) controlParameters
-             * @param (Object) callbacks
              *
              * @return (Promise)
              *
@@ -274,41 +273,50 @@ Branch.prototype.createBranchUniversalObject = function (options) {
              *    |  $blackberry_url   |   String   |   Blackberry URL  |
              *    | $windows_phone_url |   String   |  Kindle Fire URL  |
              *    -------------------------------------------------------
-             *
-             * callbacks: 
-             *    -----------------------------------------------------------------------------------------------
-             *    |             KEY            |     TYPE     |                    DESCRIPTION                  |
-             *    -----------------------------------------------------------------------------------------------
-             *    |    onShareSheetDismissed   |   Function   |  Callback listener for `onShareSheetDismissed`  |
-             *    |    onShareSheetDismissed   |   Function   |  Callback listener for `onShareSheetLaunched`   |
-             *    |     onLinkShareResponse    |   Function   |  Callback listener for `onLinkShareResponse`    |
-             *    |      onChannelSelected     |   Function   |  Callback listener for `onChannelSelected`      |
-             *    -----------------------------------------------------------------------------------------------
              */
-            obj.showShareSheet = function (options, controlParameters, callbacks) {
-
-                // If no callback set, we'll default it to an empty function
-                if ( ! callbacks.onShareSheetDismissed) {
-                    callbacks.onShareSheetDismissed = function () {};
-                }
-                if ( ! callbacks.onShareSheetLaunched) {
-                    callbacks.onShareSheetLaunched = function () {};
-                }
-                if ( ! callbacks.onLinkShareResponse) {
-                    callbacks.onLinkShareResponse = function () {};
-                }
-                if ( ! callbacks.onChannelSelected) {
-                    callbacks.onChannelSelected = function () {};
-                }
-
-                // Set listener callbacks
-                executeCallback('onShareLinkDialogDismissed', callbacks.onShareSheetDismissed, [obj.instanceId]);
-                executeCallback('onShareLinkDialogLaunched', callbacks.onShareSheetLaunched, [obj.instanceId]);
-                executeCallback('onLinkShareResponse', callbacks.onLinkShareResponse, [obj.instanceId]);
-                executeCallback('onChannelSelected', callbacks.onChannelSelected, [obj.instanceId]);
+            obj.showShareSheet = function (options, controlParameters) {
 
                 return execute('showShareSheet', [obj.instanceId, options, controlParameters]);
 
+            };
+
+            /**        
+             * Set on share sheet launched listener callback.     
+             *        
+             * @param (Function) callback     
+             */
+            obj.onShareSheetLaunched = function (callback) {      
+      
+                executeCallback('onShareLinkDialogLaunched', callback, [obj.instanceId]);
+      
+            };
+
+            obj.onShareSheetDismissed = function (callback) {
+                
+                executeCallback('onShareLinkDialogDismissed', callback, [obj.instanceId]);
+
+            }
+
+            /**        
+             * Set on link share listener callback.       
+             *        
+             * @param (Function) callback     
+             */
+            obj.onLinkShareResponse = function (callback) {       
+      
+                executeCallback('onLinkShareResponse', callback, [obj.instanceId]);
+      
+            };
+      
+            /**       
+             * Set on channel select listener callback.       
+             *        
+             * @param (Function) callback     
+             */
+            obj.onChannelSelected = function (callback) {     
+      
+                executeCallback('onChannelSelected', callback, [obj.instanceId]);
+      
             };
             
             /**


### PR DESCRIPTION
Follow-up for #74 .

Addressed the following issues:

1. It seems to me (unless I am missing a larger concept) that in BranchSDK.java, we should not have only one BranchUniversalObject available. In the same vain as with the callbackContexts, calling into CreateBranchUniversalObject() just sets a class-level property called "branchObj." A suggested API would be to have Cordova return some kind of object to JS that can be used to manipulate that specific object further. Otherwise, just as with callbacks, the minute you create a second Branch Universal Object, your first one it seems like would go out the door.

2. In our execute() method in BranchSDK.java, we should fail and call callbackContext.error() in the event of a command being called while this.instance != null.