### PR TITLE
Fixes for iOS plugin (& ensure consistency w/Android implementation)

### DIFF
--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -289,14 +289,14 @@ public class BranchSDK extends CordovaPlugin
 
         JSONObject sessionParams = this.instance.getLatestReferringParams();
 
-        if (sessionParams == null) {
+        if (sessionParams == null || sessionParams.length() == 0) {
             Log.d(LCAT, "return is null");
+            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, /* send boolean: false as the data */ false));
         } else {
             Log.d(LCAT, "return is not null");
             Log.d(LCAT, sessionParams.toString());
+            callbackContext.success(sessionParams);
         }
-
-        callbackContext.success(sessionParams);
 
     }
 
@@ -316,14 +316,14 @@ public class BranchSDK extends CordovaPlugin
 
         JSONObject installParams = this.instance.getFirstReferringParams();
 
-        if (installParams == null) {
+        if (installParams == null || installParams.length() == 0) {
             Log.d(LCAT, "return is null");
+            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, /* send boolean: false as the data */ false));
         } else {
             Log.d(LCAT, "return is not null");
             Log.d(LCAT, installParams.toString());
+            callbackContext.success(installParams);
         }
-
-        callbackContext.success(installParams);
 
     }
 


### PR DESCRIPTION
Issues addressed in this PR:

Android:
1. getFirstReferringParams() and getLatestReferringParams() will now return boolean false when no params are available (trying to serialize a null will throw an exception) or when the received object is null. The behavior now matches iOS.

iOS:
1. initSession will now resolve a promise with the latest param data
2. logout now resolves a promise
3. userCompletedAction now resolves a promise, but like the Android equivalent, it is too early (e.g. before we receive confirmation from the server) but I didn’t see a method s.t. I could use a listener to wait for the response.
4. loadRewards() will now return just an int value instead of a JSON string; it is now consistent with Java
5. getCreditsHistory() will now return a straight array of entries instead of a JSON string; it is now consistent with Java
6. generateShortUrl() now returns an object with property “url” instead of a JSON string; it is now consistent with Java
7. getFirstReferringParams() and getLatestReferringParams() return an object instead of a string, and returns false if no params were available (matches Android)

Outstanding (unaddressed) issues can be found here: https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK/issues/80