### PR TITLE
resolve setDebug promise on Android & ios with passed-in value

### DIFF
--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -111,7 +111,7 @@ public class BranchSDK extends CordovaPlugin
 
         if (action.equals("setDebug")) {
             if (args.length() == 1) {
-                this.setDebug(args.getBoolean(0));
+                this.setDebug(args.getBoolean(0), callbackContext);
             }
             return true;
         } else if (action.equals("initSession")) {
@@ -577,8 +577,9 @@ public class BranchSDK extends CordovaPlugin
      * <p>If you want to flag debug, call this <b>before</b> initUserSession</p>
      *
      * @param isEnable A {@link Boolean} value to enable/disable debugging mode for the app.
+     * @param callbackContext   A callback to execute at the end of this method
      */
-    private void setDebug(boolean isEnable)
+    private void setDebug(boolean isEnable, CallbackContext callbackContext)
     {
 
         Log.d(LCAT, "start setDebug()");
@@ -591,6 +592,7 @@ public class BranchSDK extends CordovaPlugin
             debugInstance.setDebug();
         }
 
+        callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, /* send boolean: false as the data */ isEnable));
     }
 
     /**

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -122,7 +122,15 @@
 - (void)setDebug:(CDVInvokedUrlCommand*)command
 {
     NSLog(@"start setDebug");
-    [[Branch getInstance] setDebug];
+    CDVPluginResult* pluginResult;
+    bool enableDebug = [[command.arguments objectAtIndex:0] boolValue] == YES;
+    if (enableDebug) {
+        [[Branch getInstance] setDebug];
+    }
+    
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:enableDebug];
+    
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)getAutoInstance:(CDVInvokedUrlCommand*)command


### PR DESCRIPTION
Worth noting that it looks like doing the following:

initSession()
setDebug(true)
setDebug(false)

will currently leave the debug state as true since false is pretty much
a no-op. This commit at least fixes (on iOS) so that if you do
initSession() then setDebug(false), it doesn’t set debug mode to on.

Both platforms now return a proper bool value of true/false.