### PR TITLE
[FIX] Null callbackcontext for initSesison

### DIFF
--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -55,7 +55,7 @@ public class BranchSDK extends CordovaPlugin
         this.activity.setIntent(intent);
 
         if (this.activity != null) {
-            this.initSession();
+            this.initSession(null);
         }
     }
 
@@ -254,21 +254,13 @@ public class BranchSDK extends CordovaPlugin
         this.activity = this.cordova.getActivity();
 
         this.instance = Branch.getAutoInstance(this.activity.getApplicationContext());
-        this.instance.initSession(new SessionListener(callbackContext), activity.getIntent().getData(), activity);
 
-    }
+        if (callbackContext == null) {
+            this.instance.initSession(new SessionListener(), activity.getIntent().getData(), activity);            
+        } else {
+            this.instance.initSession(new SessionListener(callbackContext), activity.getIntent().getData(), activity);
+        }
 
-    /**
-     * <p>Initialises a session with the Branch API, without a callback or {@link Activity}.</p>
-     */
-    private void initSession()
-    {
-        Log.d(LCAT, "start initSession()");
-
-        this.activity = this.cordova.getActivity();
-
-        this.instance = Branch.getAutoInstance(this.activity.getApplicationContext());
-        this.instance.initSession(new SessionListener(), activity.getIntent().getData(), activity);
 
     }
 

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -55,7 +55,7 @@ public class BranchSDK extends CordovaPlugin
         this.activity.setIntent(intent);
 
         if (this.activity != null) {
-            this.initSession(null);
+            this.initSession();
         }
     }
 
@@ -255,6 +255,20 @@ public class BranchSDK extends CordovaPlugin
 
         this.instance = Branch.getAutoInstance(this.activity.getApplicationContext());
         this.instance.initSession(new SessionListener(callbackContext), activity.getIntent().getData(), activity);
+
+    }
+
+    /**
+     * <p>Initialises a session with the Branch API, without a callback or {@link Activity}.</p>
+     */
+    private void initSession()
+    {
+        Log.d(LCAT, "start initSession()");
+
+        this.activity = this.cordova.getActivity();
+
+        this.instance = Branch.getAutoInstance(this.activity.getApplicationContext());
+        this.instance.initSession(new SessionListener(), activity.getIntent().getData(), activity);
 
     }
 
@@ -776,9 +790,12 @@ public class BranchSDK extends CordovaPlugin
     {
         private CallbackContext _callbackContext;
 
-        // Constructor that takes in a required callbackContext object
         public SessionListener(CallbackContext callbackContext) {
             this._callbackContext = callbackContext;
+        }
+
+        public SessionListener() {
+            this._callbackContext = null;
         }
 
         //Listener that implements BranchReferralInitListener for initSession
@@ -790,6 +807,10 @@ public class BranchSDK extends CordovaPlugin
             String out = String.format("DeepLinkHandler(%s)", referringParams.toString());
 
             webView.sendJavascript(out);
+
+            if (this._callbackContext == null) {
+                return;
+            }
 
             if (error == null) {
 


### PR DESCRIPTION
Fixed `initSession` on new intent handler wherein it doesn't pass any `callbackContext`.