### PR TITLE
[FIX] Increased minimum Cordova build version.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -51,7 +51,7 @@ SOFTWARE.
     <hook src="hooks/beforePluginInstallHook.js" type="before_plugin_install" />
 
     <engines>
-        <engine name="cordova" version=">=3.0.0" />
+        <engine name="cordova" version=">=3.5.0" />
     </engines>
 
     <!-- android -->


### PR DESCRIPTION
Increased minimum Cordova build version to support 64-bit for iOS.
See this [article](http://phonegap.com/blog/2015/01/20/ios-64bit-support/)