### PR TITLE
[FIX] Issue with iOS crash which string value was not handled properly.

### DIFF
--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -538,7 +538,14 @@
 - (void)postUnhandledURL:(NSNotification *)notification {
     // We create a JSON string result, because we're unable to handle the url. We will include the url in the return string.
     NSError *error;
-    NSString *urlString = [notification.object absoluteString];
+    NSString *urlString;
+
+    if ([notification.object respondsToSelector:@selector(absoluteString:)]) {
+        urlString = [notification.object absoluteString];
+    } else {
+        urlString = notification.object;
+    }
+    
     NSDictionary *returnDict = [NSDictionary dictionaryWithObjectsAndKeys:@"Unable to process URL", @"error", urlString, @"url", nil];
     NSData* returnJSON = [NSJSONSerialization dataWithJSONObject:returnDict
                                                          options:NSJSONWritingPrettyPrinted


### PR DESCRIPTION
In regards to issue #116 .
Wherein `NSString` was not handled properly for null returns.